### PR TITLE
Support Edge NAT for APIC ML2 workflow

### DIFF
--- a/deployment_scripts/puppet/modules/cisco_aci/manifests/router_plugin.pp
+++ b/deployment_scripts/puppet/modules/cisco_aci/manifests/router_plugin.pp
@@ -28,6 +28,9 @@ class cisco_aci::router_plugin(
        $splugin = "networking_cisco.plugins.cisco.service_plugins.cisco_device_manager_plugin.CiscoDeviceManagerPlugin,networking_cisco.plugins.cisco.service_plugins.cisco_router_plugin.CiscoRouterPlugin,group_policy,servicechain,neutron.services.metering.metering_plugin.MeteringPlugin"
     } else {
        $splugin = "networking_cisco.plugins.cisco.service_plugins.cisco_device_manager_plugin.CiscoDeviceManagerPlugin,networking_cisco.plugins.cisco.service_plugins.cisco_router_plugin.CiscoRouterPlugin,neutron.services.metering.metering_plugin.MeteringPlugin"
+       neutron_plugin_ml2_cisco {
+         "ml2_cisco_apic/l3_cisco_router_plugin": value => True;
+       }
     }
     neutron_config {
       "DEFAULT/service_plugins": value => $splugin;


### PR DESCRIPTION
When APIC ML2 workflow is used with Edge NAT, an additional config
file option needs to be set for the apic-ml2-driver. This option
tells the apic-ml2-driver that the ASR plugin is used for the L3
solution.