### PR TITLE
Fix L2 mode flag with Edge NAT

### DIFF
--- a/deployment_scripts/puppet/modules/cisco_aci/manifests/router_plugin.pp
+++ b/deployment_scripts/puppet/modules/cisco_aci/manifests/router_plugin.pp
@@ -28,6 +28,9 @@ class cisco_aci::router_plugin(
        $splugin = "networking_cisco.plugins.cisco.service_plugins.cisco_device_manager_plugin.CiscoDeviceManagerPlugin,networking_cisco.plugins.cisco.service_plugins.cisco_router_plugin.CiscoRouterPlugin,group_policy,servicechain,neutron.services.metering.metering_plugin.MeteringPlugin"
     } else {
        $splugin = "networking_cisco.plugins.cisco.service_plugins.cisco_device_manager_plugin.CiscoDeviceManagerPlugin,networking_cisco.plugins.cisco.service_plugins.cisco_router_plugin.CiscoRouterPlugin,neutron.services.metering.metering_plugin.MeteringPlugin"
+       neutron_plugin_ml2_cisco {
+         "ml2_cisco_apic/l3_cisco_router_plugin": value => True;
+       }
     }
     neutron_config {
       "DEFAULT/service_plugins": value => $splugin;


### PR DESCRIPTION
For APIC ML2 mode with Edge NAT, an additional flag
needs to be set.